### PR TITLE
Don't load config from Alembic env.py

### DIFF
--- a/alembic/env.py
+++ b/alembic/env.py
@@ -1,10 +1,7 @@
 from alembic import context
 from logging.config import fileConfig
 
-from koschei.config import load_config
 from koschei.db import Base, grant_db_access, get_engine
-
-load_config(['/usr/share/koschei/config.cfg', '/etc/koschei/config-admin.cfg'])
 
 # this is the Alembic Config object, which provides
 # access to the values within the .ini file in use.


### PR DESCRIPTION
Alembic is ran from koschei-admin wrapper, which is responsible for
loading up config -- there is no need to load config for the second
time.