### PR TITLE
[frontend] Use werkzeug ProxyFix

### DIFF
--- a/koschei/frontend/__init__.py
+++ b/koschei/frontend/__init__.py
@@ -29,3 +29,6 @@ import koschei.frontend.views
 from koschei import plugin
 
 plugin.load_plugins('frontend')
+
+from werkzeug.contrib.fixers import ProxyFix
+app.wsgi_app = ProxyFix(app.wsgi_app)


### PR DESCRIPTION
When behind TLS-terminating proxy (such as OpenShift router) Flask
needs to know that it should use https URL schema for redirect URLs.