### PR TITLE
Infer build repo_id from rebuildSRPM task

### DIFF
--- a/test/data/KojiUtilOtherTest/test_koji_fault.yml
+++ b/test/data/KojiUtilOtherTest/test_koji_fault.yml
@@ -1,0 +1,115 @@
+- method: getTaskResult
+  args:
+  - 1337
+  result:
+  - tasks/1337
+  - - repomd.xml
+    - other.xml.gz
+    - filelists.xml.gz
+    - primary.xml.gz
+    - comps.xml
+- method: getTaskResult
+  args:
+  - 12345
+  exception:
+    type:
+      module: koji
+      class: GenericError
+    args:
+    - Task 12345 is canceled
+- method: getTaskResult
+  args:
+  - 41684693
+  exception:
+    type:
+      module: koji
+      class: BuildError
+    args:
+    - error building package (arch armv7hl), mock exited with status 1; see root.log
+      for more information
+- method: getTaskResult
+  args:
+  - 41684668
+  exception:
+    type:
+      module: koji
+      class: BuildError
+    args:
+    - error building package (arch armv7hl), mock exited with status 1; see root.log
+      for more information
+- method: getTaskResult
+  args:
+  - 41111818
+  exception:
+    type:
+      module: koji
+      class: BuildError
+    args:
+    - error building srpm, mock exited with status 1; see root.log for more information
+- method: getTaskResult
+  args:
+  - 41111817
+  exception:
+    type:
+      module: koji
+      class: BuildError
+    args:
+    - error building srpm, mock exited with status 1; see root.log for more information
+- method: getTaskResult
+  args:
+  - 32738401
+  exception:
+    type:
+      module: xmlrpc.client
+      class: Fault
+    args:
+    - 1
+    - "Traceback (most recent call last):\n  File \"/usr/lib/python2.7/site-packages/koji/daemon.py\"\
+      , line 1244, in runTask\n    response = (handler.run(),)\n  File \"/usr/lib/python2.7/site-packages/koji/tasks.py\"\
+      , line 307, in run\n    return koji.util.call_with_argcheck(self.handler, self.params,\
+      \ self.opts)\n  File \"/usr/lib/python2.7/site-packages/koji/util.py\", line\
+      \ 216, in call_with_argcheck\n    return func(*args, **kwargs)\n  File \"/usr/sbin/kojid\"\
+      , line 1268, in handler\n    broot.init()\n  File \"/usr/sbin/kojid\", line\
+      \ 526, in init\n    self.session.host.setBuildRootList(self.id,self.getPackageList())\n\
+      \  File \"/usr/sbin/kojid\", line 615, in getPackageList\n    self.markExternalRPMs(ret)\n\
+      \  File \"/usr/sbin/kojid\", line 722, in markExternalRPMs\n    fo = koji.openRemoteFile(relpath,\
+      \ **opts)\n  File \"/usr/lib/python2.7/site-packages/koji/__init__.py\", line\
+      \ 1605, in openRemoteFile\n    src = six.moves.urllib.request.urlopen(url)\n\
+      \  File \"/usr/lib64/python2.7/urllib2.py\", line 154, in urlopen\n    return\
+      \ opener.open(url, data, timeout)\n  File \"/usr/lib64/python2.7/urllib2.py\"\
+      , line 435, in open\n    response = meth(req, response)\n  File \"/usr/lib64/python2.7/urllib2.py\"\
+      , line 548, in http_response\n    'http', request, response, code, msg, hdrs)\n\
+      \  File \"/usr/lib64/python2.7/urllib2.py\", line 473, in error\n    return\
+      \ self._call_chain(*args)\n  File \"/usr/lib64/python2.7/urllib2.py\", line\
+      \ 407, in _call_chain\n    result = func(*args)\n  File \"/usr/lib64/python2.7/urllib2.py\"\
+      , line 556, in http_error_default\n    raise HTTPError(req.get_full_url(), code,\
+      \ msg, hdrs, fp)\nHTTPError: HTTP Error 503: Backend fetch failed\n"
+- method: getTaskResult
+  args:
+  - 32738626
+  exception:
+    type:
+      module: xmlrpc.client
+      class: Fault
+    args:
+    - 1
+    - "Traceback (most recent call last):\n  File \"/usr/lib/python2.7/site-packages/koji/daemon.py\"\
+      , line 1244, in runTask\n    response = (handler.run(),)\n  File \"/usr/lib/python2.7/site-packages/koji/tasks.py\"\
+      , line 307, in run\n    return koji.util.call_with_argcheck(self.handler, self.params,\
+      \ self.opts)\n  File \"/usr/lib/python2.7/site-packages/koji/util.py\", line\
+      \ 216, in call_with_argcheck\n    return func(*args, **kwargs)\n  File \"/usr/sbin/kojid\"\
+      , line 1268, in handler\n    broot.init()\n  File \"/usr/sbin/kojid\", line\
+      \ 526, in init\n    self.session.host.setBuildRootList(self.id,self.getPackageList())\n\
+      \  File \"/usr/sbin/kojid\", line 615, in getPackageList\n    self.markExternalRPMs(ret)\n\
+      \  File \"/usr/sbin/kojid\", line 722, in markExternalRPMs\n    fo = koji.openRemoteFile(relpath,\
+      \ **opts)\n  File \"/usr/lib/python2.7/site-packages/koji/__init__.py\", line\
+      \ 1605, in openRemoteFile\n    src = six.moves.urllib.request.urlopen(url)\n\
+      \  File \"/usr/lib64/python2.7/urllib2.py\", line 154, in urlopen\n    return\
+      \ opener.open(url, data, timeout)\n  File \"/usr/lib64/python2.7/urllib2.py\"\
+      , line 435, in open\n    response = meth(req, response)\n  File \"/usr/lib64/python2.7/urllib2.py\"\
+      , line 548, in http_response\n    'http', request, response, code, msg, hdrs)\n\
+      \  File \"/usr/lib64/python2.7/urllib2.py\", line 473, in error\n    return\
+      \ self._call_chain(*args)\n  File \"/usr/lib64/python2.7/urllib2.py\", line\
+      \ 407, in _call_chain\n    result = func(*args)\n  File \"/usr/lib64/python2.7/urllib2.py\"\
+      , line 556, in http_error_default\n    raise HTTPError(req.get_full_url(), code,\
+      \ msg, hdrs, fp)\nHTTPError: HTTP Error 503: Backend fetch failed\n"

--- a/test/data/PollingTest/test_poll_failed_rebuildSRPM.yml
+++ b/test/data/PollingTest/test_poll_failed_rebuildSRPM.yml
@@ -1,0 +1,62 @@
+- method: getTaskInfo
+  args:
+  - 41111817
+  result:
+    arch: noarch
+    awaited: null
+    channel_id: 1
+    completion_time: '2020-01-27 23:52:02.639836'
+    completion_ts: 1580169122.63984
+    create_time: '2020-01-27 23:50:27.744662'
+    create_ts: 1580169027.74466
+    host_id: 83
+    id: 41111817
+    label: null
+    method: build
+    owner: 3199
+    parent: null
+    priority: 50
+    start_time: '2020-01-27 23:50:28.087738'
+    start_ts: 1580169028.08774
+    state: 5
+    waiting: true
+    weight: 0.2
+- method: getTaskResult
+  args:
+  - 41111817
+  exception:
+    type:
+      module: koji
+      class: BuildError
+    args:
+    - error building srpm, mock exited with status 1; see root.log for more information
+- method: getTaskChildren
+  args:
+  - 41111817
+  kwargs:
+    request: true
+  result:
+  - arch: noarch
+    awaited: false
+    channel_id: 1
+    completion_time: '2020-01-27 23:51:45.372959'
+    completion_ts: 1580169105.37296
+    create_time: '2020-01-27 23:50:28.804249'
+    create_ts: 1580169028.80425
+    host_id: 294
+    id: 41111818
+    label: srpm
+    method: rebuildSRPM
+    owner: 3199
+    parent: 41111817
+    priority: 49
+    request:
+    - ../packages/python-debtcollector/1.22.0/2.fc32/src/python-debtcollector-1.22.0-2.fc32.src.rpm
+    - 11522
+    - repo_id: 1344909
+      scratch: true
+    start_time: '2020-01-27 23:50:29.351542'
+    start_ts: 1580169029.35154
+    state: 5
+    waiting: null
+    weight: 1.0

--- a/test/koji_util_test.py
+++ b/test/koji_util_test.py
@@ -166,3 +166,23 @@ class KojiUtilOtherTest(AbstractTest):
             'https://primary-koji.test/repos/f29-build/888027/x86_64',
             desc.url,
         )
+
+    @with_koji_cassette
+    def test_koji_fault(self):
+        koji_sesion = self.koji('primary')
+        # Successful task
+        self.assertFalse(koji_util.is_koji_fault(koji_sesion, 1337))
+        # Cancelled task
+        self.assertFalse(koji_util.is_koji_fault(koji_sesion, 12345))
+        # Failed buildArch task (non-fault)
+        self.assertFalse(koji_util.is_koji_fault(koji_sesion, 41684693))
+        # Failed build task (non-fault)
+        self.assertFalse(koji_util.is_koji_fault(koji_sesion, 41684668))
+        # Failed rebuildSRPM (non-fault)
+        self.assertFalse(koji_util.is_koji_fault(koji_sesion, 41111818))
+        # Failed scratch build from SRPM (non-fault)
+        self.assertFalse(koji_util.is_koji_fault(koji_sesion, 41111817))
+        # Failed build task due to HTTPError: HTTP Error 503: Backend fetch failed
+        self.assertTrue(koji_util.is_koji_fault(koji_sesion, 32738401))
+        # Failed buildArch task due to HTTPError: HTTP Error 503: Backend fetch failed
+        self.assertTrue(koji_util.is_koji_fault(koji_sesion, 32738626))

--- a/test/koji_vcr.py
+++ b/test/koji_vcr.py
@@ -136,7 +136,7 @@ class KojiVCR(object):
                 else:
                     module = builtins
                 exc_class = getattr(module, classname)
-                return exc_class(*replay['exception']['args'])
+                raise exc_class(*replay['exception']['args'])
             return replay['result']
         if not self.recording:
             arguments = [f'{arg!r}' for arg in args]
@@ -161,6 +161,8 @@ class KojiVCR(object):
             record_item['exception']['type']['module'] = type(e).__module__
             record_item['exception']['type']['class'] = type(e).__name__
             record_item['exception']['args'] = list(e.args)
+            if type(e).__module__ == 'xmlrpc.client' and type(e).__name__ == 'Fault':
+                record_item['exception']['args'] = [e.__dict__['faultCode'], e.__dict__['faultString']]
             self.record_list.append(record_item)
             raise e
 


### PR DESCRIPTION
When there are no buildArch tasks then rebuildSRPM task can also be used to deduce repo_id from.
Fixes #310