### PR TITLE
Make distgit group refresh script use extras JSON

### DIFF
--- a/bin/koschei-refresh-distgit-group
+++ b/bin/koschei-refresh-distgit-group
@@ -6,4 +6,5 @@ fi
 set -e
 group_name="${1}"; shift
 distgit_group_name="${1}"; shift
-curl -s "https://src.fedoraproject.org/api/0/group/${distgit_group_name}?projects=1" | jq -r '.projects[]|select(.namespace=="rpms").name' | koschei-admin edit-group "${group_name}" --content-from-file - "${@}"
+
+curl -s https://src.fedoraproject.org/extras/pagure_bz.json | jq -r '.rpms|to_entries[]|select(.value[]=="@'"${distgit_group_name}"'").key' | koschei-admin edit-group "${group_name}" --content-from-file - "${@}"


### PR DESCRIPTION
Pagure broke its API, starting to require pagination.  Unfortunately
Pagure pagination is prone to race conditions and returns inconsistent
data. Not to mention it's slow and complex to use.  As such it can't
be relied on by Koschei.

The koschei-refresh-distgit-group script is changed to use data
produced extras JSON produced by pagure-dist-git instead of Pagure
API.