### PR TITLE
Use the new koschei-messages schema package

### DIFF
--- a/.travis/Dockerfile
+++ b/.travis/Dockerfile
@@ -1,10 +1,11 @@
-FROM registry.fedoraproject.org/fedora:33
+FROM registry.fedoraproject.org/fedora:35
 
 WORKDIR /build
 
 RUN echo -e "deltarpm=0\ninstall_weak_deps=0\ntsflags=nodocs" >> /etc/dnf/dnf.conf
 RUN dnf -y update
-RUN dnf -y install curl findutils postgresql-server python3-coverage python3-devel python3-dogpile-cache python3-fedora-messaging python3-flask python3-flask-sqlalchemy python3-flask-wtf python3-hawkey python3-humanize python3-jinja2 python3-markupsafe python3-koji python3-librepo python3-mock python3-nose python3-psycopg2 python3-requests python3-rpm python3-setuptools python3-sqlalchemy python3-vcrpy python3-wtforms systemd
+RUN dnf -y install curl findutils postgresql-server python3-coverage python3-devel python3-dogpile-cache python3-fedora-messaging python3-flask python3-flask-sqlalchemy python3-flask-wtf python3-hawkey python3-humanize python3-jinja2 python3-markupsafe python3-koji python3-librepo python3-mock python3-nose python3-psycopg2 python3-requests python3-rpm python3-setuptools python3-sqlalchemy python3-vcrpy python3-wtforms systemd python3-pip
+RUN pip-3 install koschei-messages
 
 RUN useradd koschei
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,12 @@ RUN : \
  && useradd koschei \
  && :
 
+# Install koschei-messages from PyPI as it is not packaged yet
+RUN : \
+ && dnf -y install python3-pip \
+ && pip-3 install koschei-messages==1.0.1 \
+ && :
+
 COPY bin/ /usr/bin/
 COPY ./ /usr/share/koschei/
 

--- a/koschei/plugins/fedmsg_plugin/backend/publisher.py
+++ b/koschei/plugins/fedmsg_plugin/backend/publisher.py
@@ -18,6 +18,8 @@
 # Author: Mikolaj Izdebski <mizdebsk@redhat.com>
 
 import fedora_messaging.api as fedmsg
+from koschei_messages.package import PackageStateChange
+from koschei_messages.collection import CollectionStateChange
 
 from koschei.config import get_config
 from koschei.plugin import listen_event
@@ -26,10 +28,6 @@ from koschei.plugin import listen_event
 def publish_fedmsg(session, message):
     if not get_config('fedmsg-publisher.enabled', False):
         return
-    message = fedmsg.Message(
-        topic='{modname}.{topic}'.format(**message),
-        body=message['msg'],
-    )
     session.log.info('Publishing fedmsg:\n' + str(message))
     fedmsg.publish(message)
 
@@ -39,10 +37,11 @@ def emit_package_state_update(session, package, prev_state, new_state):
     if prev_state == new_state:
         return
     group_names = [group.full_name for group in package.groups]
-    message = dict(
-        topic='package.state.change',
-        modname=get_config('fedmsg-publisher.modname'),
-        msg=dict(
+    message = PackageStateChange(
+        topic='{modname}.package.state.change'.format(
+            modname=get_config('fedmsg-publisher.modname')
+        ),
+        body=dict(
             name=package.name,
             old=prev_state,
             new=new_state,
@@ -60,10 +59,11 @@ def emit_package_state_update(session, package, prev_state, new_state):
 def emit_collection_state_update(session, collection, prev_state, new_state):
     if prev_state == new_state:
         return
-    message = dict(
-        topic='collection.state.change',
-        modname=get_config('fedmsg-publisher.modname'),
-        msg=dict(
+    message = CollectionStateChange(
+        topic='{modname}.collection.state.change'.format(
+            modname=get_config('fedmsg-publisher.modname')
+        ),
+        body=dict(
             old=prev_state,
             new=new_state,
             koji_instance=get_config('fedmsg.instance'),

--- a/test/fedmsg_publisher_test.py
+++ b/test/fedmsg_publisher_test.py
@@ -18,7 +18,8 @@
 
 from mock import patch
 from test.common import DBTest
-from fedora_messaging.api import Message
+from koschei_messages.package import PackageStateChange
+from koschei_messages.collection import CollectionStateChange
 from koschei import plugin
 from koschei.models import PackageGroup, PackageGroupRelation
 
@@ -36,7 +37,7 @@ class FedmsgSenderTest(DBTest):
             plugin.dispatch_event('package_state_change', self.session, package=package,
                                   prev_state='failed', new_state='ok')
             publish.assert_called_once_with(
-                Message(
+                PackageStateChange(
                     topic='koschei.package.state.change',
                     body={'name': 'rnv',
                           'old': 'failed',
@@ -52,7 +53,7 @@ class FedmsgSenderTest(DBTest):
             plugin.dispatch_event('collection_state_change', self.session, collection=package.collection,
                                   prev_state='unresolved', new_state='ok')
             publish.assert_called_once_with(
-                Message(
+                CollectionStateChange(
                     topic='koschei.collection.state.change',
                     body={'old': 'unresolved',
                           'new': 'ok',
@@ -71,8 +72,8 @@ class FedmsgSenderTest(DBTest):
         with patch('fedora_messaging.api.publish') as publish:
             plugin.dispatch_event('package_state_change', self.session, package=package,
                                   prev_state='ok', new_state='ok')
-            self.assertFalse(publish.called)
+            publish.assert_not_called()
             publish.reset_mock()
             plugin.dispatch_event('collection_state_change', self.session, collection=package.collection,
                                   prev_state='ok', new_state='ok')
-            self.assertFalse(publish.called)
+            publish.assert_not_called()

--- a/test/resolver_test.py
+++ b/test/resolver_test.py
@@ -21,9 +21,10 @@ from unittest import skipIf
 
 import hawkey
 import koji
-from fedora_messaging.api import Message
 from contextlib import contextmanager
 from mock import Mock, patch
+from koschei_messages.collection import CollectionStateChange
+from koschei_messages.package import PackageStateChange
 
 from test.common import DBTest, RepoCacheMock, rpmvercmp
 from koschei import plugin
@@ -107,7 +108,7 @@ class ResolverTest(DBTest):
 
     def assert_collection_fedmsg_emitted(self, fedmsg_mock, prev_state, new_state):
         fedmsg_mock.assert_called_once_with(
-            Message(
+            CollectionStateChange(
                 topic='koschei.collection.state.change',
                 body={'old': prev_state,
                       'new': new_state,
@@ -316,7 +317,7 @@ class ResolverTest(DBTest):
             self.assertFalse(result.resolved)
             self.assertIn('nonexistent', ''.join(map(str, result.problems)))
             fedmsg_mock.assert_called_once_with(
-                Message(
+                PackageStateChange(
                     topic='koschei.package.state.change',
                     body={'koji_instance': 'primary',
                           'repo': 'f25',
@@ -359,7 +360,7 @@ class ResolverTest(DBTest):
             self.assertTrue(result.resolved)
             self.assertEqual([], result.problems)
             fedmsg_mock.assert_called_once_with(
-                Message(
+                PackageStateChange(
                     topic='koschei.package.state.change',
                     body={'koji_instance': 'primary',
                           'repo': 'f25',


### PR DESCRIPTION
This change will make use of the new schema package, which will let FMN produce notifications for users.

Ref: https://github.com/fedora-infra/fmn/issues/915

Caveats:
- The schema package is not in Fedora yet, it's installed from PyPI for now.
- There is currently no schema for the messages sent by the OSCI plugin, but it's not as urgent as they are not as directly useful for user notifications.